### PR TITLE
Remove TargetHostedZoneId parameter AllowedPattern

### DIFF
--- a/launch-lrs/launch-lrs-route53.json
+++ b/launch-lrs/launch-lrs-route53.json
@@ -39,8 +39,9 @@
 			"Type": "String"
 		},
 		"TargetHostedZoneId": {
-			"AllowedPattern": "^[A-Z0-9]{14}$",
 			"Description": "For instance Z117KPS5GTRQ2G. See https://docs.aws.amazon.com/general/latest/gr/elasticbeanstalk.html for possible values",
+			"MaxLength": 15,
+			"MinLength": 1,
 			"Type": "String"
 		},
 		"HostedZoneId": {


### PR DESCRIPTION
AWS seems to have used different patterns for HostedZoneId in different
regions